### PR TITLE
fix: AITEAM-83 always make cli destination folder

### DIFF
--- a/src/scripts/main.sh
+++ b/src/scripts/main.sh
@@ -130,7 +130,7 @@ basic_name="cci-$EVAL_PLATFORM-eval"
 binary_name="${basic_name}-${binary_version}-${PLATFORM}-${ARCH}"
 binary_zip="${orb_bin_dir}/${binary_name}.zip"
 # Where to move the binary
-path_destination="/home/circleci/bin"
+path_destination="$HOME/bin"
 # Slack orb seems to put this outside the script as a parameter
 # https://github.com/CircleCI-Public/slack-orb-go/blob/8c4e86c9a787c240138244610aada066059b5b46/src/commands/notify.yml#L80
 # TODO: keep support for this? Or will people not bother? They would have to do to the packagecloud URL and find it
@@ -192,6 +192,12 @@ fi
 
 printf '%s\n' "Moving $binary_name to PATH and renaming to ${basic_name}..."
 mkdir -p "$path_destination"
+# shellcheck disable=SC2016
+# shellcheck disable=SC2086
+echo 'export PATH='${path_destination}':$PATH' >> "$BASH_ENV"
+# shellcheck disable=SC1090
+# shellcheck disable=SC3046
+source "$BASH_ENV"
 if ! mv "$orb_bin_dir/$binary_name" "${path_destination}/${basic_name}"; then
     print_error "Failed to move $orb_bin_dir/$binary_name binary executable."
     exit 1

--- a/src/scripts/main.sh
+++ b/src/scripts/main.sh
@@ -191,6 +191,7 @@ if ! chmod +x "${orb_bin_dir}/${binary_name}"; then
 fi
 
 printf '%s\n' "Moving $binary_name to PATH and renaming to ${basic_name}..."
+mkdir -p "$path_destination"
 if ! mv "$orb_bin_dir/$binary_name" "${path_destination}/${basic_name}"; then
     print_error "Failed to move $orb_bin_dir/$binary_name binary executable."
     exit 1


### PR DESCRIPTION
Bug definition:

using any images other than `cimg/***` was causing failures on using the orb because, we are expecting the cli to be placed in `home/circleci/...` base folder. But, some images setup home as `/root`.

Fix:
now we always try to make the destination so cli can be moved in there.

working version https://app.circleci.com/pipelines/github/CircleCI-Public/llm-eval-examples/32/workflows/e9d44a40-4c1b-4c02-a30b-9bf3ec3c87ab/jobs/88