### PR TITLE
feat: support EVALS_SHELL env var for custom command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ _Some of the parameters are optional based on the eval platform being used._
 
 - **`cmd`**: Command to run the evaluation
 
-- **`eval_platform`**: Evaluation platform (e.g. `braintrust`, `langsmith` etc.; default: `braintrust`)
+- **`eval_platform`**: Evaluation platform (e.g. `braintrust`, `langsmith` or `custom`; default: `custom`)
 
 - **`evals_result_location`**: Location to save evaluation results (default: `./results`)
+
+- **`shell`**: Shell to use (default: `/bin/bash`). This param only applies when `eval_platform` is not provided or is set to `custom`.
 
 #### Braintrust-specific parameters
 

--- a/src/commands/eval.yml
+++ b/src/commands/eval.yml
@@ -49,7 +49,7 @@ steps:
         BRAINTRUST_EXPERIMENT_NAME: << parameters.braintrust_experiment_name >>
         CCI_LANGCHAIN_EXPERIMENT_NAME: << parameters.langsmith_experiment_name >>
         LANGCHAIN_ENDPOINT: << parameters.langsmith_endpoint >>
-        SHELL: << parameters.shell >>
+        EVALS_SHELL: << parameters.shell >>
       command: |
         if [ "$EVAL_PLATFORM" == "custom" ]; then
           cci-eval custom << parameters.cmd >>

--- a/src/commands/eval.yml
+++ b/src/commands/eval.yml
@@ -30,6 +30,10 @@ parameters:
       - braintrust
       - langsmith
       - custom
+  shell:
+    description: shell to use
+    type: string
+    default: /bin/bash
 steps:
   - run:
       name: Download << parameters.eval_platform >> eval binary
@@ -45,6 +49,7 @@ steps:
         BRAINTRUST_EXPERIMENT_NAME: << parameters.braintrust_experiment_name >>
         CCI_LANGCHAIN_EXPERIMENT_NAME: << parameters.langsmith_experiment_name >>
         LANGCHAIN_ENDPOINT: << parameters.langsmith_endpoint >>
+        SHELL: << parameters.shell >>
       command: |
         if [ "$EVAL_PLATFORM" == "custom" ]; then
           cci-eval custom << parameters.cmd >>

--- a/src/examples/run_eval_with_custom_command.yml
+++ b/src/examples/run_eval_with_custom_command.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    evals: circleci/evals@0.0
+    evals: circleci/evals@1.0
   jobs:
     aibraintrust-eval:
       docker:
@@ -13,6 +13,7 @@ usage:
         - evals/eval:
             circle_pipeline_id: << pipeline.id >>
             cmd: run_a_custom_command
+            shell: /bin/bash
   workflows:
     evals-workflow:
       jobs:

--- a/src/scripts/main.sh
+++ b/src/scripts/main.sh
@@ -125,7 +125,7 @@ case $EVAL_PLATFORM in
     binary_version="v0.0.3"
     ;;
     "custom")
-    binary_version="v0.0.1"
+    binary_version="v0.0.2"
     ;;
     *)
     echo "Unknown platform: $EVAL_PLATFORM" >&2


### PR DESCRIPTION
- when the orb is used to run a custom command, now orb accepts an `optional` param `shell`. It defaults to `/bin/bash`.
- it runs as `/bin/bash -C <custom_command>`